### PR TITLE
Default and custom headers for requests

### DIFF
--- a/lib/api_model/class_methods.rb
+++ b/lib/api_model/class_methods.rb
@@ -29,7 +29,7 @@ module ApiModel
       cache cache_id(path, options) do
         request = HttpRequest.new path: path, method: method, config: api_model_configuration
         request.builder = options.delete(:builder) || api_model_configuration.builder || self
-        request.options.merge! options
+        request.options.deep_merge! options
         request.run.build_objects
       end
     end

--- a/spec/api-model/http_request_spec.rb
+++ b/spec/api-model/http_request_spec.rb
@@ -58,6 +58,17 @@ describe ApiModel::HttpRequest do
     it 'should use the default accept header' do
       request_headers["Accept"].should eq ApiModel::Configuration.new.headers["Accept"]
     end
+
+    it 'should retain the default headers when making requests with custom headers added' do
+      BlogPost.api_config { |config| config.host = "http://api-model-specs.com" }
+      custom_headers = { headers: { "Custom" => "Header" } }
+      blog_post = VCR.use_cassette('posts') { BlogPost.get_json "/single_post", {}, custom_headers }
+      headers = blog_post.http_response.api_call.request.options[:headers]
+
+      headers.should have_key "Custom"
+      headers.should have_key "Accept"
+      headers.should have_key "Content-Type"
+    end
   end
 
   describe "sending a GET request" do


### PR DESCRIPTION
Adds test and fix for overridden default headers when providing custom headers for requests

![jrznzsu](https://cloud.githubusercontent.com/assets/492335/5085077/8242b93c-6f0e-11e4-9dcf-e6e13aadf361.gif)
