### PR TITLE
Nested errors

### DIFF
--- a/lib/api_model/instance_methods.rb
+++ b/lib/api_model/instance_methods.rb
@@ -29,11 +29,21 @@ module ApiModel
       errors_hash.each do |field,messages|
         if messages.is_a?(Array)
           messages.each do |message|
-            obj.errors.add field.to_sym, message
+            set_error_on_self_or_child field, message, obj
           end
         else
-          obj.errors.add field.to_sym, messages
+          set_error_on_self_or_child field, messages, obj
         end
+      end
+    end
+
+    # If the field to apply errors to is another ApiModel instance, call ++set_errors_from_hash++ on it.
+    # Otherwise, go ahead and treat it as a normal ActiveModel error on the current ++obj++ instance.
+    def set_error_on_self_or_child(field, messages, obj = self)
+      if obj.respond_to?(field.to_sym) && obj.send(field.to_sym).respond_to?(:set_error_on_self_or_child)
+        obj.send(field.to_sym).set_errors_from_hash messages
+      else
+        obj.errors.add field.to_sym, messages
       end
     end
 

--- a/spec/api-model/api_model_spec.rb
+++ b/spec/api-model/api_model_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'support/mock_models/blog_post'
 require 'support/mock_models/car'
 require 'support/mock_models/user'
+require 'support/mock_models/garage'
 
 describe ApiModel do
 
@@ -161,6 +162,23 @@ describe ApiModel do
 
     it 'should return false if errors is not a hash' do
       car.set_errors_from_hash("Foobar").should be_false
+    end
+  end
+
+  describe "setting errors on nested models" do
+    let(:car) { Car.new }
+    let(:garage) { Garage.new car: car }
+
+    before do
+      garage.set_errors_from_hash style: "is invalid", car: { name: "sounds funny" }
+    end
+
+    it 'should set errors on the parent normally' do
+      garage.errors[:style].should eq ["is invalid"]
+    end
+
+    it 'should set errors on the child normally' do
+      garage.car.errors[:name].should eq ["sounds funny"]
     end
   end
 

--- a/spec/api-model/api_model_spec.rb
+++ b/spec/api-model/api_model_spec.rb
@@ -309,7 +309,7 @@ describe ApiModel do
     it 'should not pass custom cache_ids onto api requests' do
       expect {
         VCR.use_cassette('posts') { BlogPost.get_json "http://api-model-specs.com/single_post", {}, cache_id: "custom_key" }
-      }.to_not raise_error(Ethon::Errors::InvalidOption)
+      }.to_not raise_error
     end
   end
 

--- a/spec/support/mock_models/garage.rb
+++ b/spec/support/mock_models/garage.rb
@@ -1,0 +1,4 @@
+class Garage < ApiModel::Base
+  attribute :car, Car
+  attribute :style, String
+end


### PR DESCRIPTION
Handle errors on child objects properly rather than assuming everything is an attribute.

@erkie 