### PR TITLE
Internally rename HttpRequest#before_run/after_run to #before_run_request/after_run_request to get around a bug in Rails 4.2

### DIFF
--- a/lib/api_model/http_request.rb
+++ b/lib/api_model/http_request.rb
@@ -6,14 +6,23 @@ module ApiModel
 
     after_initialize :set_default_options
 
-    define_model_callbacks :run
+    define_model_callbacks :run_request
+
+    # There is a bug in Rails 4.2 where you can't create instances of classes that have `define_model_callbacks :run`
+    # To get around this we internally rename the callback to `run_request`, and alias the methods `before_run` to `before_run_request`
+    # This can be removed when the Rails version is fixed.
+    class << self
+      alias_method :around_run, :around_run_request
+      alias_method :before_run, :before_run_request
+      alias_method :after_run, :after_run_request
+    end
 
     def config
       @config ||= Configuration.new
     end
 
     def run
-      run_callbacks :run do
+      run_callbacks :run_request do
         Log.debug "#{method.to_s.upcase} #{full_path} with headers: #{options[:headers]}"
         self.api_call = Typhoeus.send method, full_path, options
         Response.new self, config


### PR DESCRIPTION
The bug occurs if you `define_model_callbacks :run`, which then clashes with an internal representation of callbacks.

To get around this, I define `define_model_callbacks :run_request` and the create class method aliases for `after_run/before_run/around_run` to keep it compatible with previous versions.

What do you think @idlefingers ?